### PR TITLE
extra print statement for namespace example

### DIFF
--- a/hello-world/helloworld.py
+++ b/hello-world/helloworld.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
-
+import os 
 import platform
 
 message = """Hello from within the container!
 
-This container is running Python version {python_version}.
-""".format(python_version=platform.python_version())
+This container is running Python version {python_version} 
+\nRunning file located in {file_loc}.
+""".format(python_version=platform.python_version(),
+           file_loc=os.path.dirname(os.path.realpath(__file__)))
 
 if __name__ == '__main__':
     print(message)


### PR DESCRIPTION
Highlights to following distinction between `exec` and `run`:

```
mario@pop-os:~/containers/container-workshop/hello-world$ singularity run helloworld2.simg 
Hello from within the container!

This container is running Python version 3.5.2 

Running file located in /opt.

mario@pop-os:~/containers/container-workshop/hello-world$ singularity exec helloworld2.simg python3 helloworld.py
Hello from within the container!

This container is running Python version 3.5.2 

Running file located in /home/mario/containers/container-workshop/hello-world.
```